### PR TITLE
PiggySDK using wrong interface.

### DIFF
--- a/src/SDK/PiggySDK.php
+++ b/src/SDK/PiggySDK.php
@@ -7,7 +7,7 @@ use GuzzleHttp\Client;
 use GuzzleHttp\Psr7\Request;
 use Psr\Http\Message\ResponseInterface;
 use TechShark\LaravelPiggy\Managers\PiggyManager;
-use TechShark\LaravelPiggy\SDK\Requests\Interfaces\PiggySDKParameterInterface;
+use TechShark\LaravelPiggy\SDK\Requests\Interfaces\PiggyRequestInterface;
 
 /**
  * Class PiggySDK
@@ -42,13 +42,13 @@ class PiggySDK
     /**
      * Fire an API call.
      *
-     * @param PiggySDKParameterInterface $SDKRequest
+     * @param PiggyRequestInterface $SDKRequest
      *
      * @return mixed|\Psr\Http\Message\ResponseInterface
      *
      * @throws \GuzzleHttp\Exception\GuzzleException
      */
-    public function call(PiggySDKParameterInterface $SDKRequest): ResponseInterface
+    public function call(PiggyRequestInterface $SDKRequest): ResponseInterface
     {
         $fullUrl = $this->buildUrl($SDKRequest->getEndpoint(), $SDKRequest->getArguments(), $SDKRequest->getHttpMethod());
 

--- a/src/SDK/Requests/Interfaces/PiggyParameterInterface.php
+++ b/src/SDK/Requests/Interfaces/PiggyParameterInterface.php
@@ -1,14 +1,15 @@
 <?php
+declare(strict_types=1);
 
 namespace TechShark\LaravelPiggy\SDK\Requests\Interfaces;
 
 /**
- * Interface PiggySDKRequestInterface
+ * Class PiggyParameterInterface
  *
  * @author Tyler Brennan < info@techshark.nl >
  * @version 1.0
  */
-interface PiggySDKRequestInterface
+interface PiggyParameterInterface
 {
     /**
      * Should return the endpoint to which the
@@ -24,10 +25,7 @@ interface PiggySDKRequestInterface
      * Should return an array of arguments
      * the SDK should include in the API request.
      *
-     * Ideally the arguments should be validated when calling this function.
-     * @see \TechShark\LaravelPiggy\SDK\Requests\Interfaces\PiggySDKParameterInterface::validateRequirements
-     *
-     * Example: ['shopId' => 1]
+     * Example: ['shop_id' => 1]
      *
      * @return array
      */
@@ -42,4 +40,15 @@ interface PiggySDKRequestInterface
      * @return string
      */
     public function getHttpMethod(): string;
+
+    /**
+     * Should validate all requirements set
+     * by the Piggy loyalty API on the specific
+     * request.
+     *
+     * Example: 'Email' can only be null if 'QrCode' is not null.
+     *
+     * @return bool
+     */
+    public function validateRequirements(): bool;
 }

--- a/src/SDK/Requests/Interfaces/PiggyRequestInterface.php
+++ b/src/SDK/Requests/Interfaces/PiggyRequestInterface.php
@@ -1,15 +1,14 @@
 <?php
-declare(strict_types=1);
 
 namespace TechShark\LaravelPiggy\SDK\Requests\Interfaces;
 
 /**
- * Class PiggySDKParameterInterface
+ * Interface PiggyRequestInterface
  *
  * @author Tyler Brennan < info@techshark.nl >
  * @version 1.0
  */
-interface PiggySDKParameterInterface
+interface PiggyRequestInterface
 {
     /**
      * Should return the endpoint to which the
@@ -25,7 +24,10 @@ interface PiggySDKParameterInterface
      * Should return an array of arguments
      * the SDK should include in the API request.
      *
-     * Example: ['shop_id' => 1]
+     * Ideally the arguments should be validated when calling this function.
+     * @see \TechShark\LaravelPiggy\SDK\Requests\Interfaces\PiggyParameterInterface::validateRequirements
+     *
+     * Example: ['shopId' => 1]
      *
      * @return array
      */
@@ -40,15 +42,4 @@ interface PiggySDKParameterInterface
      * @return string
      */
     public function getHttpMethod(): string;
-
-    /**
-     * Should validate all requirements set
-     * by the Piggy loyalty API on the specific
-     * request.
-     *
-     * Example: 'Email' can only be null if 'QrCode' is not null.
-     *
-     * @return bool
-     */
-    public function validateRequirements(): bool;
 }

--- a/src/SDK/Requests/Parameters/CreditReceptions/CreateCreditReceptionRequestParameter.php
+++ b/src/SDK/Requests/Parameters/CreditReceptions/CreateCreditReceptionRequestParameter.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 namespace TechShark\LaravelPiggy\SDK\Requests\Parameters\CreditReceptions;
 
 use PHPUnit\Framework\Assert;
-use TechShark\LaravelPiggy\SDK\Requests\Interfaces\PiggySDKParameterInterface;
+use TechShark\LaravelPiggy\SDK\Requests\Interfaces\PiggyParameterInterface;
 
 /**
  * Class PiggyCreateCreditReceptionRequestParameter
@@ -12,7 +12,7 @@ use TechShark\LaravelPiggy\SDK\Requests\Interfaces\PiggySDKParameterInterface;
  * @author Tyler Brennan < info@techshark.nl >
  * @version 1.0
  */
-class CreateCreditReceptionRequestParameter implements PiggySDKParameterInterface
+class CreateCreditReceptionRequestParameter implements PiggyParameterInterface
 {
     /**
      * @var int

--- a/src/SDK/Requests/Parameters/Customers/CustomerExistsRequestParameter.php
+++ b/src/SDK/Requests/Parameters/Customers/CustomerExistsRequestParameter.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 namespace TechShark\LaravelPiggy\SDK\Requests\Parameters\Customers;
 
 use PHPUnit\Framework\Assert;
-use TechShark\LaravelPiggy\SDK\Requests\Interfaces\PiggySDKParameterInterface;
+use TechShark\LaravelPiggy\SDK\Requests\Interfaces\PiggyParameterInterface;
 
 /**
  * Class CustomerExistsRequestParameter
@@ -12,7 +12,7 @@ use TechShark\LaravelPiggy\SDK\Requests\Interfaces\PiggySDKParameterInterface;
  * @author Tyler Brennan < info@techshark.nl >
  * @version 1.0
  */
-class CustomerExistsRequestParameter implements PiggySDKParameterInterface
+class CustomerExistsRequestParameter implements PiggyParameterInterface
 {
     /**
      * @var null|string

--- a/src/SDK/Requests/Parameters/Giftcards/ChangeGiftcardExpirationDateRequestParameter.php
+++ b/src/SDK/Requests/Parameters/Giftcards/ChangeGiftcardExpirationDateRequestParameter.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 namespace TechShark\LaravelPiggy\SDK\Requests\Parameters\Giftcards;
 
 use PHPUnit\Framework\ExpectationFailedException;
-use TechShark\LaravelPiggy\SDK\Requests\Interfaces\PiggySDKParameterInterface;
+use TechShark\LaravelPiggy\SDK\Requests\Interfaces\PiggyParameterInterface;
 
 /**
  * Class ChangeGiftcardExpirationDateRequestParameter
@@ -12,7 +12,7 @@ use TechShark\LaravelPiggy\SDK\Requests\Interfaces\PiggySDKParameterInterface;
  * @author Tyler Brennan < info@techshark.nl >
  * @version 1.0
  */
-class ChangeGiftcardExpirationDateRequestParameter implements PiggySDKParameterInterface
+class ChangeGiftcardExpirationDateRequestParameter implements PiggyParameterInterface
 {
     /**
      * @var string

--- a/src/SDK/Requests/Parameters/Giftcards/ChangeGiftcardStatusRequestParameter.php
+++ b/src/SDK/Requests/Parameters/Giftcards/ChangeGiftcardStatusRequestParameter.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 namespace TechShark\LaravelPiggy\SDK\Requests\Parameters\Giftcards;
 
 use TechShark\LaravelPiggy\Enums\GiftcardStatus;
-use TechShark\LaravelPiggy\SDK\Requests\Interfaces\PiggySDKParameterInterface;
+use TechShark\LaravelPiggy\SDK\Requests\Interfaces\PiggyParameterInterface;
 
 /**
  * Class ChangeGiftcardStatusRequestParameter
@@ -12,7 +12,7 @@ use TechShark\LaravelPiggy\SDK\Requests\Interfaces\PiggySDKParameterInterface;
  * @author Tyler Brennan < info@techshark.nl >
  * @version 1.0
  */
-class ChangeGiftcardStatusRequestParameter implements PiggySDKParameterInterface
+class ChangeGiftcardStatusRequestParameter implements PiggyParameterInterface
 {
     /**
      * @var string

--- a/src/SDK/Requests/Parameters/Giftcards/CreateGiftcardTransactionRequestParameter.php
+++ b/src/SDK/Requests/Parameters/Giftcards/CreateGiftcardTransactionRequestParameter.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 namespace TechShark\LaravelPiggy\SDK\Requests\Parameters\Giftcards;
 
-use TechShark\LaravelPiggy\SDK\Requests\Interfaces\PiggySDKParameterInterface;
+use TechShark\LaravelPiggy\SDK\Requests\Interfaces\PiggyParameterInterface;
 
 /**
  * Class CreateGiftcardTransactionRequestParameter
@@ -11,7 +11,7 @@ use TechShark\LaravelPiggy\SDK\Requests\Interfaces\PiggySDKParameterInterface;
  * @author Tyler Brennan < info@techshark.nl >
  * @version 1.0
  */
-class CreateGiftcardTransactionRequestParameter implements PiggySDKParameterInterface
+class CreateGiftcardTransactionRequestParameter implements PiggyParameterInterface
 {
     /**
      * @var float

--- a/src/SDK/Requests/Parameters/Giftcards/GetGiftcardDetailRequestParameter.php
+++ b/src/SDK/Requests/Parameters/Giftcards/GetGiftcardDetailRequestParameter.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 namespace TechShark\LaravelPiggy\SDK\Requests\Parameters\Giftcards;
 
-use TechShark\LaravelPiggy\SDK\Requests\Interfaces\PiggySDKParameterInterface;
+use TechShark\LaravelPiggy\SDK\Requests\Interfaces\PiggyParameterInterface;
 
 /**
  * Class GetGiftcardDetailRequestParameter
@@ -11,7 +11,7 @@ use TechShark\LaravelPiggy\SDK\Requests\Interfaces\PiggySDKParameterInterface;
  * @author Tyler Brennan < info@techshark.nl >
  * @version 1.0
  */
-class GetGiftcardDetailRequestParameter implements PiggySDKParameterInterface
+class GetGiftcardDetailRequestParameter implements PiggyParameterInterface
 {
 
     /**

--- a/src/SDK/Requests/Parameters/Giftcards/GetGiftcardRequestParameter.php
+++ b/src/SDK/Requests/Parameters/Giftcards/GetGiftcardRequestParameter.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 namespace TechShark\LaravelPiggy\SDK\Requests\Parameters\Giftcards;
 
-use TechShark\LaravelPiggy\SDK\Requests\Interfaces\PiggySDKParameterInterface;
+use TechShark\LaravelPiggy\SDK\Requests\Interfaces\PiggyParameterInterface;
 
 /**
  * Class GetGiftcardRequestParameter
@@ -11,7 +11,7 @@ use TechShark\LaravelPiggy\SDK\Requests\Interfaces\PiggySDKParameterInterface;
  * @author Tyler Brennan < info@techshark.nl >
  * @version 1.0
  */
-class GetGiftcardRequestParameter implements PiggySDKParameterInterface
+class GetGiftcardRequestParameter implements PiggyParameterInterface
 {
 
     /**

--- a/src/SDK/Requests/Parameters/Giftcards/GetGiftcardTransactionsRequestParameter.php
+++ b/src/SDK/Requests/Parameters/Giftcards/GetGiftcardTransactionsRequestParameter.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 namespace TechShark\LaravelPiggy\SDK\Requests\Parameters\Giftcards;
 
-use TechShark\LaravelPiggy\SDK\Requests\Interfaces\PiggySDKParameterInterface;
+use TechShark\LaravelPiggy\SDK\Requests\Interfaces\PiggyParameterInterface;
 
 /**
  * Class GetGiftcardTransactionsRequestParameter
@@ -11,7 +11,7 @@ use TechShark\LaravelPiggy\SDK\Requests\Interfaces\PiggySDKParameterInterface;
  * @author Tyler Brennan < info@techshark.nl >
  * @version 1.0
  */
-class GetGiftcardTransactionsRequestParameter implements PiggySDKParameterInterface
+class GetGiftcardTransactionsRequestParameter implements PiggyParameterInterface
 {
     /**
      * @var string

--- a/src/SDK/Requests/Parameters/PointOfSale/CreatePOSTransactionRequestParameter.php
+++ b/src/SDK/Requests/Parameters/PointOfSale/CreatePOSTransactionRequestParameter.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 namespace TechShark\LaravelPiggy\SDK\Requests\Parameters\PointOfSale;
 
 use Ramsey\Uuid\UuidInterface;
-use TechShark\LaravelPiggy\SDK\Requests\Interfaces\PiggySDKParameterInterface;
+use TechShark\LaravelPiggy\SDK\Requests\Interfaces\PiggyParameterInterface;
 
 /**
  * Class CreatePOSTransactionRequestParameter
@@ -12,7 +12,7 @@ use TechShark\LaravelPiggy\SDK\Requests\Interfaces\PiggySDKParameterInterface;
  * @author Tyler Brennan < info@techshark.nl >
  * @version 1.0
  */
-class CreatePOSTransactionRequestParameter implements PiggySDKParameterInterface
+class CreatePOSTransactionRequestParameter implements PiggyParameterInterface
 {
     /**
      * @var int

--- a/src/SDK/Requests/Parameters/PointOfSale/PushPOSTransactionRequestParameter.php
+++ b/src/SDK/Requests/Parameters/PointOfSale/PushPOSTransactionRequestParameter.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 namespace TechShark\LaravelPiggy\SDK\Requests\Parameters\PointOfSale;
 
-use TechShark\LaravelPiggy\SDK\Requests\Interfaces\PiggySDKParameterInterface;
+use TechShark\LaravelPiggy\SDK\Requests\Interfaces\PiggyParameterInterface;
 
 /**
  * Class PushPOSTransactionRequestParameter
@@ -11,7 +11,7 @@ use TechShark\LaravelPiggy\SDK\Requests\Interfaces\PiggySDKParameterInterface;
  * @author Tyler Brennan < info@techshark.nl >
  * @version 1.0
  */
-class PushPOSTransactionRequestParameter implements PiggySDKParameterInterface
+class PushPOSTransactionRequestParameter implements PiggyParameterInterface
 {
     /**
      * @var int

--- a/src/SDK/Requests/Parameters/Rewards/GetRewardsRequestParameter.php
+++ b/src/SDK/Requests/Parameters/Rewards/GetRewardsRequestParameter.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 namespace TechShark\LaravelPiggy\SDK\Requests\Parameters\Rewards;
 
-use TechShark\LaravelPiggy\SDK\Requests\Interfaces\PiggySDKParameterInterface;
+use TechShark\LaravelPiggy\SDK\Requests\Interfaces\PiggyParameterInterface;
 
 /**
  * Class GetRewardsRequestParameter
@@ -11,7 +11,7 @@ use TechShark\LaravelPiggy\SDK\Requests\Interfaces\PiggySDKParameterInterface;
  * @author Tyler Brennan < info@techshark.nl >
  * @version 1.0
  */
-class GetRewardsRequestParameter implements PiggySDKParameterInterface
+class GetRewardsRequestParameter implements PiggyParameterInterface
 {
     /**
      * @var int

--- a/src/SDK/Requests/Parameters/Shop/GetActiveShopRequestParameter.php
+++ b/src/SDK/Requests/Parameters/Shop/GetActiveShopRequestParameter.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 namespace TechShark\LaravelPiggy\SDK\Requests\Parameters\Shop;
 
-use TechShark\LaravelPiggy\SDK\Requests\Interfaces\PiggySDKParameterInterface;
+use TechShark\LaravelPiggy\SDK\Requests\Interfaces\PiggyParameterInterface;
 
 /**
  * Class GetActiveShopRequestParameter
@@ -11,7 +11,7 @@ use TechShark\LaravelPiggy\SDK\Requests\Interfaces\PiggySDKParameterInterface;
  * @author Tyler Brennan < info@techshark.nl >
  * @version 1.0
  */
-class GetActiveShopRequestParameter implements PiggySDKParameterInterface
+class GetActiveShopRequestParameter implements PiggyParameterInterface
 {
     /**
      * @var string

--- a/src/SDK/Requests/PiggyRequest.php
+++ b/src/SDK/Requests/PiggyRequest.php
@@ -3,8 +3,8 @@ declare(strict_types=1);
 
 namespace TechShark\LaravelPiggy\SDK\Requests;
 
-use TechShark\LaravelPiggy\SDK\Requests\Interfaces\PiggySDKParameterInterface;
-use TechShark\LaravelPiggy\SDK\Requests\Interfaces\PiggySDKRequestInterface;
+use TechShark\LaravelPiggy\SDK\Requests\Interfaces\PiggyParameterInterface;
+use TechShark\LaravelPiggy\SDK\Requests\Interfaces\PiggyRequestInterface;
 
 /**
  * Class PiggyRequest
@@ -12,19 +12,19 @@ use TechShark\LaravelPiggy\SDK\Requests\Interfaces\PiggySDKRequestInterface;
  * @author Tyler Brennan < info@techshark.nl >
  * @version 1.0
  */
-class PiggyRequest implements PiggySDKRequestInterface
+class PiggyRequest implements PiggyRequestInterface
 {
     /**
-     * @var PiggySDKParameterInterface
+     * @var PiggyParameterInterface
      */
     private $piggySDKParameters;
 
     /**
      * PiggyRequest constructor.
      *
-     * @param PiggySDKParameterInterface $piggySDKParameters
+     * @param PiggyParameterInterface $piggySDKParameters
      */
-    public function __construct(PiggySDKParameterInterface $piggySDKParameters)
+    public function __construct(PiggyParameterInterface $piggySDKParameters)
     {
         $this->piggySDKParameters = $piggySDKParameters;
     }

--- a/src/Tests/CreditReceptions/CreateCreditReceptionRequestTest.php
+++ b/src/Tests/CreditReceptions/CreateCreditReceptionRequestTest.php
@@ -5,7 +5,7 @@ namespace TechShark\LaravelPiggy\Tests\CreditReceptions;
 
 use PHPUnit\Framework\ExpectationFailedException;
 use PHPUnit\Framework\TestCase;
-use TechShark\LaravelPiggy\SDK\Requests\Interfaces\PiggySDKParameterInterface;
+use TechShark\LaravelPiggy\SDK\Requests\Interfaces\PiggyParameterInterface;
 use TechShark\LaravelPiggy\SDK\Requests\Parameters\CreditReceptions\CreateCreditReceptionRequestParameter;
 
 /**
@@ -81,9 +81,9 @@ class CreateCreditReceptionRequestTest extends TestCase
     }
 
     /**
-     * @return PiggySDKParameterInterface
+     * @return PiggyParameterInterface
      */
-    private function getSDKRequestObject(): PiggySDKParameterInterface
+    private function getSDKRequestObject(): PiggyParameterInterface
     {
         return new CreateCreditReceptionRequestParameter(
             1,
@@ -97,9 +97,9 @@ class CreateCreditReceptionRequestTest extends TestCase
     }
 
     /**
-     * @return PiggySDKParameterInterface
+     * @return PiggyParameterInterface
      */
-    private function getInvalidSDKRequestObject(): PiggySDKParameterInterface
+    private function getInvalidSDKRequestObject(): PiggyParameterInterface
     {
         return new CreateCreditReceptionRequestParameter(
             1,

--- a/src/Tests/Customers/CustomerExistsRequestTest.php
+++ b/src/Tests/Customers/CustomerExistsRequestTest.php
@@ -5,7 +5,7 @@ namespace TechShark\LaravelPiggy\Tests\Customers;
 
 use PHPUnit\Framework\ExpectationFailedException;
 use PHPUnit\Framework\TestCase;
-use TechShark\LaravelPiggy\SDK\Requests\Interfaces\PiggySDKParameterInterface;
+use TechShark\LaravelPiggy\SDK\Requests\Interfaces\PiggyParameterInterface;
 use TechShark\LaravelPiggy\SDK\Requests\Parameters\Customers\CustomerExistsRequestParameter;
 
 /**
@@ -78,9 +78,9 @@ class CustomerExistsRequestTest extends TestCase
     }
 
     /**
-     * @return PiggySDKParameterInterface
+     * @return PiggyParameterInterface
      */
-    private function getSDKRequestObject(): PiggySDKParameterInterface
+    private function getSDKRequestObject(): PiggyParameterInterface
     {
         return new CustomerExistsRequestParameter(
             'example@example.com',
@@ -89,9 +89,9 @@ class CustomerExistsRequestTest extends TestCase
     }
 
     /**
-     * @return PiggySDKParameterInterface
+     * @return PiggyParameterInterface
      */
-    private function getInvalidSDKRequestObject(): PiggySDKParameterInterface
+    private function getInvalidSDKRequestObject(): PiggyParameterInterface
     {
         return new CustomerExistsRequestParameter(
             'example@example.com',

--- a/src/Tests/Giftcards/ChangeGiftcardExpirationDateRequestTest.php
+++ b/src/Tests/Giftcards/ChangeGiftcardExpirationDateRequestTest.php
@@ -5,7 +5,7 @@ namespace TechShark\LaravelPiggy\Tests\Giftcards;
 
 use PHPUnit\Framework\ExpectationFailedException;
 use PHPUnit\Framework\TestCase;
-use TechShark\LaravelPiggy\SDK\Requests\Interfaces\PiggySDKParameterInterface;
+use TechShark\LaravelPiggy\SDK\Requests\Interfaces\PiggyParameterInterface;
 use TechShark\LaravelPiggy\SDK\Requests\Parameters\Giftcards\ChangeGiftcardExpirationDateRequestParameter;
 
 /**
@@ -82,10 +82,10 @@ class ChangeGiftcardExpirationDateRequestTest extends TestCase
     }
 
     /**
-     * @return PiggySDKParameterInterface
+     * @return PiggyParameterInterface
      * @throws \Exception
      */
-    private function getSDKRequestObject(): PiggySDKParameterInterface
+    private function getSDKRequestObject(): PiggyParameterInterface
     {
         // add 1 day.
         $dateInterval = new \DateInterval('P1D');
@@ -98,10 +98,10 @@ class ChangeGiftcardExpirationDateRequestTest extends TestCase
     }
 
     /**
-     * @return PiggySDKParameterInterface
+     * @return PiggyParameterInterface
      * @throws \Exception
      */
-    private function getInvalidSDKRequestObject(): PiggySDKParameterInterface
+    private function getInvalidSDKRequestObject(): PiggyParameterInterface
     {
         // Subtract 1 day
         $dateInterval = new \DateInterval('P1D');

--- a/src/Tests/Giftcards/ChangeGiftcardStatusRequestTest.php
+++ b/src/Tests/Giftcards/ChangeGiftcardStatusRequestTest.php
@@ -5,7 +5,7 @@ namespace TechShark\LaravelPiggy\Tests\Giftcards;
 
 use PHPUnit\Framework\TestCase;
 use TechShark\LaravelPiggy\Enums\GiftcardStatus;
-use TechShark\LaravelPiggy\SDK\Requests\Interfaces\PiggySDKParameterInterface;
+use TechShark\LaravelPiggy\SDK\Requests\Interfaces\PiggyParameterInterface;
 use TechShark\LaravelPiggy\SDK\Requests\Parameters\Giftcards\ChangeGiftcardStatusRequestParameter;
 
 /**
@@ -73,9 +73,9 @@ class ChangeGiftcardStatusRequestTest extends TestCase
     }
 
     /**
-     * @return PiggySDKParameterInterface
+     * @return PiggyParameterInterface
      */
-    private function getSDKRequestObject(): PiggySDKParameterInterface
+    private function getSDKRequestObject(): PiggyParameterInterface
     {
         return new ChangeGiftcardStatusRequestParameter(
             'w0101d',

--- a/src/Tests/Giftcards/CreateGiftcardTransactionRequestTest.php
+++ b/src/Tests/Giftcards/CreateGiftcardTransactionRequestTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 namespace TechShark\LaravelPiggy\Tests\Giftcards;
 
 use PHPUnit\Framework\TestCase;
-use TechShark\LaravelPiggy\SDK\Requests\Interfaces\PiggySDKParameterInterface;
+use TechShark\LaravelPiggy\SDK\Requests\Interfaces\PiggyParameterInterface;
 use TechShark\LaravelPiggy\SDK\Requests\Parameters\Giftcards\CreateGiftcardTransactionRequestParameter;
 
 /**
@@ -75,9 +75,9 @@ class CreateGiftcardTransactionRequestTest extends TestCase
     }
 
     /**
-     * @return PiggySDKParameterInterface
+     * @return PiggyParameterInterface
      */
-    private function getSDKRequestObject(): PiggySDKParameterInterface
+    private function getSDKRequestObject(): PiggyParameterInterface
     {
         return new CreateGiftcardTransactionRequestParameter(
             100.00,

--- a/src/Tests/Giftcards/GetGiftcardDetailRequestTest.php
+++ b/src/Tests/Giftcards/GetGiftcardDetailRequestTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 namespace TechShark\LaravelPiggy\Tests\Giftcards;
 
 use PHPUnit\Framework\TestCase;
-use TechShark\LaravelPiggy\SDK\Requests\Interfaces\PiggySDKParameterInterface;
+use TechShark\LaravelPiggy\SDK\Requests\Interfaces\PiggyParameterInterface;
 use TechShark\LaravelPiggy\SDK\Requests\Parameters\Giftcards\GetGiftcardDetailRequestParameter;
 
 /**
@@ -71,9 +71,9 @@ class GetGiftcardDetailRequestTest extends TestCase
     }
 
     /**
-     * @return PiggySDKParameterInterface
+     * @return PiggyParameterInterface
      */
-    private function getSDKRequestObject(): PiggySDKParameterInterface
+    private function getSDKRequestObject(): PiggyParameterInterface
     {
         return new GetGiftcardDetailRequestParameter(
             'w0101d'

--- a/src/Tests/Giftcards/GetGiftcardTransactionsRequestTest.php
+++ b/src/Tests/Giftcards/GetGiftcardTransactionsRequestTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 namespace TechShark\LaravelPiggy\Tests\Giftcards;
 
 use PHPUnit\Framework\TestCase;
-use TechShark\LaravelPiggy\SDK\Requests\Interfaces\PiggySDKParameterInterface;
+use TechShark\LaravelPiggy\SDK\Requests\Interfaces\PiggyParameterInterface;
 use TechShark\LaravelPiggy\SDK\Requests\Parameters\Giftcards\GetGiftcardTransactionsRequestParameter;
 
 /**
@@ -71,9 +71,9 @@ class GetGiftcardTransactionsRequestTest extends TestCase
     }
 
     /**
-     * @return PiggySDKParameterInterface
+     * @return PiggyParameterInterface
      */
-    private function getSDKRequestObject(): PiggySDKParameterInterface
+    private function getSDKRequestObject(): PiggyParameterInterface
     {
         return new GetGiftcardTransactionsRequestParameter(
             'w0101d'

--- a/src/Tests/Giftcards/GetGiftcardsRequestTest.php
+++ b/src/Tests/Giftcards/GetGiftcardsRequestTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 namespace TechShark\LaravelPiggy\Tests\Giftcards;
 
 use PHPUnit\Framework\TestCase;
-use TechShark\LaravelPiggy\SDK\Requests\Interfaces\PiggySDKParameterInterface;
+use TechShark\LaravelPiggy\SDK\Requests\Interfaces\PiggyParameterInterface;
 use TechShark\LaravelPiggy\SDK\Requests\Parameters\Giftcards\GetGiftcardRequestParameter;
 
 /**
@@ -58,9 +58,9 @@ class GetGiftcardsRequestTest extends TestCase
     }
 
     /**
-     * @return PiggySDKParameterInterface
+     * @return PiggyParameterInterface
      */
-    private function getSDKRequestObject(): PiggySDKParameterInterface
+    private function getSDKRequestObject(): PiggyParameterInterface
     {
         return new GetGiftcardRequestParameter();
     }

--- a/src/Tests/PointOfSale/CreatePOSTransactionRequestTest.php
+++ b/src/Tests/PointOfSale/CreatePOSTransactionRequestTest.php
@@ -5,7 +5,7 @@ namespace TechShark\LaravelPiggy\Tests\PointOfSale;
 
 use PHPUnit\Framework\TestCase;
 use Ramsey\Uuid\Uuid;
-use TechShark\LaravelPiggy\SDK\Requests\Interfaces\PiggySDKParameterInterface;
+use TechShark\LaravelPiggy\SDK\Requests\Interfaces\PiggyParameterInterface;
 use TechShark\LaravelPiggy\SDK\Requests\Parameters\PointOfSale\CreatePOSTransactionRequestParameter;
 
 /**
@@ -96,9 +96,9 @@ class CreatePOSTransactionRequestTest extends TestCase
     }
 
     /**
-     * @return PiggySDKParameterInterface
+     * @return PiggyParameterInterface
      */
-    private function getSDKRequestObject(): PiggySDKParameterInterface
+    private function getSDKRequestObject(): PiggyParameterInterface
     {
         return new CreatePOSTransactionRequestParameter(
             1,

--- a/src/Tests/PointOfSale/PushPOSTransactionRequestTest.php
+++ b/src/Tests/PointOfSale/PushPOSTransactionRequestTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 namespace TechShark\LaravelPiggy\Tests\PointOfSale;
 
 use PHPUnit\Framework\TestCase;
-use TechShark\LaravelPiggy\SDK\Requests\Interfaces\PiggySDKParameterInterface;
+use TechShark\LaravelPiggy\SDK\Requests\Interfaces\PiggyParameterInterface;
 use TechShark\LaravelPiggy\SDK\Requests\Parameters\PointOfSale\PushPOSTransactionRequestParameter;
 
 /**
@@ -61,9 +61,9 @@ class PushPOSTransactionRequestTest extends TestCase
     }
 
     /**
-     * @return PiggySDKParameterInterface
+     * @return PiggyParameterInterface
      */
-    private function getSDKRequestObject(): PiggySDKParameterInterface
+    private function getSDKRequestObject(): PiggyParameterInterface
     {
         return new PushPOSTransactionRequestParameter(
             1

--- a/src/Tests/Rewards/GetRewardsRequestTest.php
+++ b/src/Tests/Rewards/GetRewardsRequestTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 namespace TechShark\LaravelPiggy\Tests\Rewards;
 
 use PHPUnit\Framework\TestCase;
-use TechShark\LaravelPiggy\SDK\Requests\Interfaces\PiggySDKParameterInterface;
+use TechShark\LaravelPiggy\SDK\Requests\Interfaces\PiggyParameterInterface;
 use TechShark\LaravelPiggy\SDK\Requests\Parameters\Rewards\GetRewardsRequestParameter;
 
 /**
@@ -72,9 +72,9 @@ class GetRewardsRequestTest extends TestCase
     }
 
     /**
-     * @return PiggySDKParameterInterface
+     * @return PiggyParameterInterface
      */
-    private function getSDKRequestObject(): PiggySDKParameterInterface
+    private function getSDKRequestObject(): PiggyParameterInterface
     {
         return new GetRewardsRequestParameter(
             1

--- a/src/Tests/Shop/GetActiveShopRequestTest.php
+++ b/src/Tests/Shop/GetActiveShopRequestTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 namespace TechShark\LaravelPiggy\Tests\Shop;
 
 use PHPUnit\Framework\TestCase;
-use TechShark\LaravelPiggy\SDK\Requests\Interfaces\PiggySDKParameterInterface;
+use TechShark\LaravelPiggy\SDK\Requests\Interfaces\PiggyParameterInterface;
 use TechShark\LaravelPiggy\SDK\Requests\Parameters\Shop\GetActiveShopRequestParameter;
 
 /**
@@ -58,9 +58,9 @@ class GetActiveShopRequestTest extends TestCase
     }
 
     /**
-     * @return PiggySDKParameterInterface
+     * @return PiggyParameterInterface
      */
-    private function getSDKRequestObject(): PiggySDKParameterInterface
+    private function getSDKRequestObject(): PiggyParameterInterface
     {
         return new GetActiveShopRequestParameter();
     }


### PR DESCRIPTION
> Rename interfaces
> Fixed bug where piggySDK was requiring the wrong interface class.